### PR TITLE
Fixed installation to be compatible with the container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 image_vector_embeddings.json
 dbs/
+.venv

--- a/1_default_text_search.py
+++ b/1_default_text_search.py
@@ -1,5 +1,6 @@
 import time
 import chromadb
+from chromadb.utils import embedding_functions
 
 client = chromadb.Client()
 print("\n### EXERCISE 1 - DEFAULT CHROMADB EMBEDDING TEXT SEARCH")
@@ -16,7 +17,9 @@ collection = client.create_collection(
     # Configure the distance / similarity metric below.
     # Can be: "l2" (euclidean), "cosine", or "ip".
     # Note that the cosine and ip is also transferred to distance metric, thus lower number is always better match.
-    metadata = { "hnsw:space": "cosine" }
+    metadata = { "hnsw:space": "cosine" },
+    embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(
+        device="cuda", normalize_embeddings=True)
 )
 print("Distance / similarity metric used: " + str(collection.metadata))
 

--- a/2_custom_text_search.py
+++ b/2_custom_text_search.py
@@ -1,6 +1,7 @@
 import os
 import time
 import chromadb
+from chromadb.utils import embedding_functions
 from embedding_helper_class import TextEmbeddingGenerator
 
 client = chromadb.Client()
@@ -33,7 +34,9 @@ collection = client.create_collection(
     # Configure the distance / similarity metric below.
     # Can be: "l2" (euclidean), "cosine", or "ip" (inner product).
     # Note that the cosine and ip is also transferred to distance metric, thus lower number is always better match.
-    metadata = { "hnsw:space": "ip" }
+    metadata = { "hnsw:space": "ip" },
+    embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(
+        device="cuda", normalize_embeddings=True)
 )
 
 print("Distance / similarity metric used: " + str(collection.metadata))

--- a/3_website_text_search.py
+++ b/3_website_text_search.py
@@ -36,7 +36,7 @@ collection = client.create_collection(
     # Note that the cosine and ip is also transferred to distance metric, thus lower number is always better match.
     metadata = { "hnsw:space": "cosine" },
     embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(
-        device="cuda", normalize_embeddings=True)
+        device="cuda", normalize_embeddings=embedder.normalize)
 )
 
 print("Distance / similarity metric used: " + str(collection.metadata))

--- a/3_website_text_search.py
+++ b/3_website_text_search.py
@@ -1,6 +1,7 @@
 import os
 import time
 import chromadb
+from chromadb.utils import embedding_functions
 from embedding_helper_class import TextEmbeddingGenerator
 
 client = chromadb.Client()
@@ -33,7 +34,9 @@ collection = client.create_collection(
     # Configure the distance / similarity metric below.
     # Can be: "l2" (euclidean), "cosine", or "ip".
     # Note that the cosine and ip is also transferred to distance metric, thus lower number is always better match.
-    metadata = { "hnsw:space": "cosine" }
+    metadata = { "hnsw:space": "cosine" },
+    embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(
+        device="cuda", normalize_embeddings=True)
 )
 
 print("Distance / similarity metric used: " + str(collection.metadata))

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,30 @@ These files are meant to be used with a NoSQL course.
 ## Setting up the Environment
 
 
+Update apt
+
+
+```bash
+sudo apt update
+```
+
+Install venv
+
+
+```bash
+sudo apt install python3-venv -y
+```
+
+Run the setup script.
+This will create a virtual environment, install the requirements and
+source the session from the virtual environment. 
+
+
 ```bash
 source setup.bash
 ```
 
-This will create a virtual environment, install the requirements and 
-source the session from the virtual environment. If you want to leave
-the virtual environment you can use:
+If you want to leave the virtual environment you can use:
 
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,10 @@
 These files are meant to be used with a NoSQL course.
 
 ## Setting up the Environment
-Install these pip packages:
 
-```
-pip install chromadb==0.5.13
-pip install "numpy<2"
+
+```bash
+source setup.bash
 ```
 
 ## Image Source

--- a/readme.md
+++ b/readme.md
@@ -9,5 +9,21 @@ These files are meant to be used with a NoSQL course.
 source setup.bash
 ```
 
+This will create a virtual environment, install the requirements and 
+source the session from the virtual environment. If you want to leave
+the virtual environment you can use:
+
+
+```bash
+deactivate
+```
+
+To source the session from the virtual environment again run:
+
+
+```bash
+source .venv/bin/activate
+```
+
 ## Image Source
 Images located in folders `db_images` and `find_images` have been created using the Adobe Firefly 2 model.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 chromadb==0.5.13
 numpy<2
 sentence-transformers==3.3.0
+torchvision==0.20.1
+beautifulsoup4==4.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+chromadb==0.5.13
+numpy<2
+sentence-transformers==3.3.0

--- a/setup.bash
+++ b/setup.bash
@@ -1,0 +1,3 @@
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt

--- a/setup.bash
+++ b/setup.bash
@@ -1,3 +1,3 @@
 python3 -m venv .venv
 source .venv/bin/activate
-python -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt


### PR DESCRIPTION
Changed Chroma to use GPU when creating embeddings, utilizing the sentence_transformers library. Updated the installation instructions, because this solution uses venv. The container did not have python3-venv installed. This latest includes instructions to install venv for the container, which allows running the new setup script, which installs all requirements and opens the venv.